### PR TITLE
Made website more friendly

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,7 @@
             <li class="dropdown">
               <a class="dropdown-toggle" data-toggle="dropdown" href="#">Community<span class="caret"></span></a>
               <ul class="dropdown-menu">
-                <li><a href="{{ site.baseurl }}/getinvolved/">Get Involved</a></li>
+                <li><a href="{{ site.baseurl }}/contactus/">Contact Us</a></li>
                 <li><a href="{{ site.baseurl }}/news/">News Archive</a></li>
                 <li><a href="{{ site.baseurl }}/people/">People</a></li>
                 <li><a href="{{ site.baseurl }}/related-projects/">Related Projects</a></li>

--- a/_posts/blog/2017-07-26-fluo-graduates-from-apache-incubator.md
+++ b/_posts/blog/2017-07-26-fluo-graduates-from-apache-incubator.md
@@ -5,11 +5,13 @@ date: 2017-07-26 06:00:00 +0000
 
 Apache Fluo graduated from the [Apache Incubator][incubator] to become a Top-Level Project!
 Graduation signifies Fluo's commitment to the meritocratic process and principles of the Apache
-Software Foundation. For more information, see the following annoucements :
+Software Foundation. For more information, see the following press annoucements :
 
  * [Apache Software Foundation blog post][post]
  * [@TheASF Tweet][tweet]
  * [NASDAQ GlobeNewswire][newswire]
+
+For general information about Fluo, checkout the [home page](/).
 
 [post]: https://blogs.apache.org/foundation/entry/the-apache-software-foundation-announces5
 [tweet]: https://twitter.com/TheASF/status/890149770551078914

--- a/_posts/release/2016-10-14-fluo-1.0.0-incubating.md
+++ b/_posts/release/2016-10-14-fluo-1.0.0-incubating.md
@@ -17,7 +17,7 @@ release for the project. Below are resources for this release:
 Starting with 1.0.0-incubating, Apache Fluo will follow [semver](http://semver.org/) for all future API
 changes. The API consists of everything under the `org.apache.fluo.api` package. Code outside of this
 package can change at any time. If your project is using Fluo code that falls outside of the API,
-then consider [initiating a discussion](/getinvolved/) about adding it to the API.
+then consider [initiating a discussion](/contactus/) about adding it to the API.
 
 ## Significant changes
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ html_title_override: true
     </div>
     <h3 style="padding-top: 0px">Overview</h3>
     <p>Apache Fluo is an open source implementation of <a href="https://research.google.com/pubs/pub36726.html" target="_blank">Percolator</a> 
-       (which populates Google's search index) for <a href="https://accumulo.apache.org/" target="_blank">Apache Accumulo</a>. Fluo makes it possible to update the results of a large-scale computation, index, or analytic as new data is discovered. For more information, take the <a href="{{ site.baseurl }}/tour/">Fluo tour</a>.</p>
+       (which populates Google's search index) for <a href="https://accumulo.apache.org/" target="_blank">Apache Accumulo</a>. With Fluo, users can continuously join new data into large existing data sets without reprocessing all data. Unlike batch and streaming frameworks, Fluo offers much lower latency and can operate on extremely large data sets. If interested in trying Fluo, take the <a href="{{ site.baseurl }}/tour/">Fluo tour</a>. For any questions you may have, <a  href="{{ site.baseurl }}/contactus/">contact us</a>.</p>
   </div>
   <div class="col-sm-4">
     <div class="row">

--- a/pages/contactus.md
+++ b/pages/contactus.md
@@ -1,10 +1,33 @@
 ---
 layout: page
-title: Get Involved
-permalink: /getinvolved/
+title: Contact Us
+permalink: /contactus/
+redirect_from: /getinvolved/
 ---
 
-Below are some ways that you can get involved with Apache Fluo:
+Contact us if you need help with :
+
+ * Deciding if Fluo is the right solution for your problem
+ * Designing a Fluo application
+ * Debugging issues with a Fluo application
+ * Reporting a bug or requesting a feature
+ * Getting started contributing.
+ * Any other question relating to Fluo.
+
+Below are the different ways to get in touch with the Fluo community.
+
+### Mailing lists
+
+The `dev` mailing list is for user questions, general discussion, announcing releases, organizing
+meet ups, etc.
+
+The `notifications` and `commits` mailing lists receive email from automated services
+and can be used to observe project activity.  Design and code review discussion happen on GitHub issues and pull request.  These discussions are archived
+to the notifications list.
+
+dev@fluo.apache.org           | [Subscribe][dev-sub]     | [Unsubscribe][dev-unsub]    | [Archive][dev-arch]
+notifications@fluo.apache.org | [Subscribe][ntfy-sub]    | [Unsubscribe][ntfy-unsub]   | [Archive][ntfy-arch]
+commits@fluo.apache.org       | [Subscribe][commits-sub] | [Unsubscribe][commits-unsub]| [Archive][commits-arch]
 
 ### Issues
 
@@ -16,26 +39,13 @@ current issues.
  * [Fluo Recipes issues][ri]
  * [Website issues][wi]
 
-### Mailing lists
-
-The `dev` mailing list is for user questions, general discussion, announcing releases, organizing
-meet ups, etc. The `notifications` and `commits` mailing lists receive email from automated services
-and can be used to observe project activity.  A lot of discussion happens on GitHub and is archived
-to the notifications list.
-
-dev@fluo.apache.org           | [Subscribe][dev-sub]     | [Unsubscribe][dev-unsub]    | [Archive][dev-arch]
-notifications@fluo.apache.org | [Subscribe][ntfy-sub]    | [Unsubscribe][ntfy-unsub]   | [Archive][ntfy-arch]
-commits@fluo.apache.org       | [Subscribe][commits-sub] | [Unsubscribe][commits-unsub]| [Archive][commits-arch]
-
 ### IRC
 
-Drop by and chat about Apache Fluo at [#fluo][fnf] on [freenode][fn].  
+Drop by and chat about Apache Fluo at [#fluo][fnf] on [freenode][fn].
 
 ### Contributions 
 
-Contributions are welcome to all Apache Fluo projects! All projects follow a
-[review-then-commit][rtc] process. If you are interested in contributing, read our [How To
-Contribute][htc] page.
+Contributions are welcome to all Apache Fluo projects! If you would like help getting started contributing, please contact us on the dev list.  We will work with you to help find something that interest you.  All projects follow a [review-then-commit][rtc] process. If you are interested in contributing, read our [How To Contribute][htc] page.
 
 [f]: https://github.com/apache/fluo
 [r]: https://github.com/apache/fluo-recipes

--- a/tour/index.md
+++ b/tour/index.md
@@ -12,9 +12,19 @@ Welcome to the Fluo tour!  The tour offers a hands on introduction to Fluo, brok
 independent steps and an exercise.  The exercise gives you a chance to apply what
 you have learned.   The tour starts by introducing Fluo's [{{ first_page.title }}]({{ first_url }}).
 
+Before starting the tour, you may be wondering how you could use Fluo. A simple
+use case shows one possible way to use Fluo: the case of counting words in
+unique documents. This could be accomplished by two MapReduce jobs: one job to
+get a unique set of documents and a following job to count words. For a large
+amount of existing data, running both jobs for a small amount of new data is
+inefficient. Fluo enables continuous, quick computations of these two joins as
+new data arrives, constantly emitting deltas of word counts.  Anything could
+consume the emitted deltas. For example, a query system could be continuously
+updated using them. Later in the tour, you can implement this use case.
+
 We recommend following the tour in order. However, all pages are listed below for review.  When on a
 tour page, the left and right keys on the keyboard can be used to navigate.  If you have any
-questions or suggestions while going through the tour, please let us know.  There are multiple
+questions or suggestions while going through the tour, please contact us.  There are multiple
 options for getting in touch : [mailing list, IRC][contact], and [Github Issues][issues].  Any
 thoughts, solutions, etc  related to this tour can also be tweeted using the hashtag
 [#apachefluotour][aft].
@@ -26,6 +36,6 @@ thoughts, solutions, etc  related to this tour can also be tweeted using the has
   1. [{{ link_to_page.title }}]({{ doc_url }})
 {% endfor %}
 
-[contact]: /getinvolved/
+[contact]: /contactus/
 [issues]: https://github.com/apache/incubator-fluo-website/issues
 [aft]: https://twitter.com/hashtag/apachefluotour


### PR DESCRIPTION
I am using text from the TLP press release and changing `getinvolved` to `contact us`.   The reason I changed this was that getinvolved seemed like we are asking potential users to make some commitment, when all they want to do is simply ask a question.