### PR TITLE
remove incubator from github links

### DIFF
--- a/pages/contactus.md
+++ b/pages/contactus.md
@@ -49,10 +49,10 @@ Contributions are welcome to all Apache Fluo projects! If you would like help ge
 
 [f]: https://github.com/apache/fluo
 [r]: https://github.com/apache/fluo-recipes
-[w]: https://github.com/apache/incubator-fluo-website
+[w]: https://github.com/apache/fluo-website
 [fi]: https://github.com/apache/fluo/issues
 [ri]: https://github.com/apache/fluo-recipes/issues
-[wi]: https://github.com/apache/incubator-fluo-website/issues
+[wi]: https://github.com/apache/fluo-website/issues
 [fnf]: irc://chat.freenode.net/fluo
 [fn]: https://freenode.net/
 [htc]: /how-to-contribute/

--- a/pages/how-to-contribute.md
+++ b/pages/how-to-contribute.md
@@ -69,10 +69,10 @@ This can be configured by common IDEs:
 
 [f]: https://github.com/apache/fluo
 [r]: https://github.com/apache/fluo-recipes
-[w]: https://github.com/apache/incubator-fluo-website
+[w]: https://github.com/apache/fluo-website
 [fi]: https://github.com/apache/fluo/issues
 [ri]: https://github.com/apache/fluo-recipes/issues
-[wi]: https://github.com/apache/incubator-fluo-website/issues
+[wi]: https://github.com/apache/fluo-website/issues
 [tutorial]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
 [stackoverflow]: http://stackoverflow.com/questions/5189560/squash-my-last-x-commits-together-using-git
 [rtc]: http://www.apache.org/foundation/glossary.html#ReviewThenCommit

--- a/pages/people.md
+++ b/pages/people.md
@@ -21,7 +21,7 @@ permalink: /people/
 
 ## Contributors
 
-GitHub also has a [contributor list](https://github.com/apache/incubator-fluo/graphs/contributors)
+GitHub also has a [contributor list](https://github.com/apache/fluo/graphs/contributors)
 based on commits.
 
 | Name                                         | Organization                        | Timezone   |

--- a/pages/poweredby.md
+++ b/pages/poweredby.md
@@ -32,7 +32,7 @@ This website was made using:
 [commons]: http://commons.apache.org/
 [curator]: http://curator.apache.org/
 [hadoop]: http://hadoop.apache.org/
-[twill]: http://twill.incubator.apache.org/
+[twill]: http://twill.apache.org/
 [zookeeper]: http://zookeeper.apache.org/
 [dropwizard]: https://dropwizard.github.io/metrics/3.1.0/
 [junit]: http://junit.org/

--- a/pages/related-projects.md
+++ b/pages/related-projects.md
@@ -27,8 +27,8 @@ list, please open an issue or submit a pull request [on Github][web-ghr].
 * [Stresso] - An example application designed to stress Apache Fluo
 
 [asf]: https://www.apache.org/
-[Fluo]: https://github.com/apache/incubator-fluo
-[Fluo Recipes]: https://github.com/apache/incubator-fluo-recipes
+[Fluo]: https://github.com/apache/fluo
+[Fluo Recipes]: https://github.com/apache/fluo-recipes
 [Muchos]: https://github.com/astralway/muchos
 [Uno]: https://github.com/astralway/uno
 [Webindex]: https://github.com/astralway/webindex
@@ -36,5 +36,5 @@ list, please open an issue or submit a pull request [on Github][web-ghr].
 [Quickstart]: https://github.com/astralway/quickstart
 [Phrasecount]: https://github.com/astralway/phrasecount
 [Jaccard]: https://github.com/keith-turner/jaccard
-[web-ghr]: https://github.com/apache/incubator-fluo-website
+[web-ghr]: https://github.com/apache/fluo-website
 [Rya]: https://rya.apache.org

--- a/pages/release-process.md
+++ b/pages/release-process.md
@@ -13,7 +13,7 @@ following command to checkout the svn repository that contains the KEYS files.  
 repository will eventually sync to the website.
 
 ```bash
-svn co https://dist.apache.org/repos/dist/release/incubator/fluo/
+svn co https://dist.apache.org/repos/dist/release/fluo/
 ```
 
 The maven release plugin will need credentials to stage artifacts.  You can provide the credentials
@@ -64,7 +64,7 @@ for `RCV`.
       for download at `https://repository.apache.org/content/repositories/orgapachefluo-REPO_ID`
     * Its very important to only close the staging repository and not release or promote it at this point.  Releasing publishes
       the artifacts to Maven central and this can not be undone.  Releasing is done after a successful vote.
-    * When closing, add a comment like `Apache Fluo (incubating) 1.1.0-rc3`
+    * When closing, add a comment like `Apache Fluo 1.2.0-rc3`
 
  4. Delete the tag created by `mvn release:pepare`.  This tag should not be pushed to Apache until
     the vote passes.  Also, a signed tag should be created instead of the one created by Maven.  So out
@@ -142,9 +142,9 @@ When the vote passes on a release candidate, follow the steps below to complete 
      This is the same svn repo mentioned earlier for the KEYS file.  Follow the [ASF guidance][sigs] for
      hashes and signatures.  This step publishes the files to the ASF mirrors.
 
- 8.  Send an email to `dev@fluo.incubator.apache.org` announcing new release.
+ 8.  Send an email to `dev@fluo.apache.org` announcing new release.
 
-[website README]: https://github.com/apache/incubator-fluo-website/blob/master/README.md
+[website README]: https://github.com/apache/fluo-website/blob/master/README.md
 [example-email]: https://lists.apache.org/thread.html/8b6ec5f17e277ed2d01e8df61eb1f1f42266cd30b9e114cb431c1c17@%3Cdev.fluo.apache.org%3E
-[KEYS]: https://www.apache.org/dist/incubator/fluo/KEYS
+[KEYS]: https://www.apache.org/dist/fluo/KEYS
 [sigs]: http://www.apache.org/dev/release-distribution.html#sigs-and-sums

--- a/tour/basic-read-write.md
+++ b/tour/basic-read-write.md
@@ -38,7 +38,7 @@ assume UTF-8 encoding when converting to bytes.
 Transactions and snapshots allocate resources and therefore have `close()` methods.  The
 try-with-resources block will automatically call `close()`, even when exceptions occur.
 
-[main]: https://github.com/apache/incubator-fluo-website/tree/fluo-tour/src/main/java/ft/Main.java
+[main]: https://github.com/apache/fluo-website/tree/fluo-tour/src/main/java/ft/Main.java
 [get]: {{ site.fluo_api_static }}/{{ site.latest_fluo_release }}/org/apache/fluo/api/client/SnapshotBase.html#get-org.apache.fluo.api.data.Bytes-org.apache.fluo.api.data.Column-
 [gets]: {{ site.fluo_api_static }}/{{ site.latest_fluo_release }}/org/apache/fluo/api/client/SnapshotBase.html#gets-java.lang.CharSequence-org.apache.fluo.api.data.Column-
 [Bytes]: {{ site.fluo_api_static }}/{{ site.latest_fluo_release }}/org/apache/fluo/api/data/Bytes.html

--- a/tour/index.md
+++ b/tour/index.md
@@ -37,5 +37,5 @@ thoughts, solutions, etc  related to this tour can also be tweeted using the has
 {% endfor %}
 
 [contact]: /contactus/
-[issues]: https://github.com/apache/incubator-fluo-website/issues
+[issues]: https://github.com/apache/fluo-website/issues
 [aft]: https://twitter.com/hashtag/apachefluotour

--- a/tour/writing-code.md
+++ b/tour/writing-code.md
@@ -8,7 +8,7 @@ obtain, edit, and run this basic skeleton.
 
 ```bash
 #clone branch with starter code
-git clone -b fluo-tour https://gitbox.apache.org/repos/asf/incubator-fluo-website fluo-tour
+git clone -b fluo-tour https://gitbox.apache.org/repos/asf/fluo-website fluo-tour
 cd fluo-tour
 
 #edit Main (all of the following excercises will require this)
@@ -21,4 +21,4 @@ mvn -q clean compile exec:java
 Because it is so closely related to the website, this starter code is located in a branch of Fluo's
 website.  The starter project has its [own readme][readme] also.
 
-[readme]: https://github.com/apache/incubator-fluo-website/tree/fluo-tour
+[readme]: https://github.com/apache/fluo-website/tree/fluo-tour


### PR DESCRIPTION
Need to get this fix in ASAP, the gitbox URL for the Fluo tour is currently broken.  I started off just fixing that and then decided to fix all of the github URLs.