### PR TITLE
Update hashes according to new ASF policy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,8 @@ permalink: pretty
 
 markdown: kramdown
 
+repository: apache/fluo-website
+
 # Collection names cannot contain periods
 collections:
   fluo-1-2:

--- a/_posts/release/2018-02-26-fluo-1.2.0.md
+++ b/_posts/release/2018-02-26-fluo-1.2.0.md
@@ -8,8 +8,8 @@ Below are resources for this release:
 
  * Download a release tarball and verify by these [procedures] using these [KEYS]
  
-   | [fluo-1.2.0-bin.tar.gz][bin-release]            | [ASC][bin-asc] [MD5][bin-md5] [SHA][bin-sha] |
-   | [fluo-1.2.0-source-release.tar.gz][src-release] | [ASC][src-asc] [MD5][src-md5] [SHA][src-sha] |
+   | [fluo-1.2.0-bin.tar.gz][bin-release]            | [ASC][bin-asc] [SHA][bin-sha] |
+   | [fluo-1.2.0-source-release.tar.gz][src-release] | [ASC][src-asc] [SHA][src-sha] |
  * View the [documentation][docs] for this release.
  * Read the [Javadocs][javadocs].
  
@@ -165,12 +165,10 @@ The Fluo stress test was run twice as documented [here](https://twitter.com/Apac
 [KEYS]: https://www.apache.org/dist/fluo/KEYS
 [bin-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz
 [bin-asc]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.asc
-[bin-md5]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.md5
-[bin-sha]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.sha
+[bin-sha]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.sha512
 [src-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz
 [src-asc]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.asc
-[src-md5]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.md5
-[src-sha]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.sha
+[src-sha]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.sha512
 [javadocs]: {{ site.fluo_api_base }}/1.2.0/
 [docs]: /docs/fluo/1.2/
 [semver]: http://semver.org/

--- a/_posts/release/2018-03-06-fluo-recipes-1.2.0.md
+++ b/_posts/release/2018-03-06-fluo-recipes-1.2.0.md
@@ -19,7 +19,7 @@ Below are resources for this release:
   </dependency>
   ```
 * A source release tarball is available. It can be verified by these [procedures] using these [KEYS]
-  * [fluo-recipes-1.2.0-source-release.tar.gz][src-release] - [ASC][src-asc] [SHA-512][sha]
+  * [fluo-recipes-1.2.0-source-release.tar.gz][src-release] - [ASC][src-asc] [SHA][src-sha]
 * View the [documentation][docs] for this release
 * Read the javadocs: <a href="{{ site.api_base }}/fluo-recipes-core/1.2.0/" target="_blank">core</a>, <a href="{{ site.api_base }}/fluo-recipes-accumulo/1.2.0/" target="_blank">accumulo</a>, <a href="{{ site.api_base }}/fluo-recipes-kryo/1.2.0/" target="_blank">kryo</a>, <a href="{{ site.api_base }}/fluo-recipes-spark/1.2.0/" target="_blank">spark</a>, <a href="{{ site.api_base }}/fluo-recipes-test/1.2.0/" target="_blank">test</a>
 * View [all changes][changes].
@@ -41,7 +41,7 @@ Fluo Recipes was updated (in [#146]) to build using Fluo 1.2.0 and Accumulo 1.7.
 [KEYS]: https://www.apache.org/dist/fluo/KEYS
 [src-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz
 [src-asc]: https://www.apache.org/dist/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.asc
-[sha]: https://www.apache.org/dist/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.sha512
+[src-sha]: https://www.apache.org/dist/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.sha512
 [docs]: /docs/fluo-recipes/1.2/
 [central]: http://search.maven.org/#search|ga|1|fluo-recipes
 [changes]: https://github.com/apache/fluo-recipes/milestone/2?closed=1

--- a/_posts/release/2018-03-06-fluo-yarn-1.0.0.md
+++ b/_posts/release/2018-03-06-fluo-yarn-1.0.0.md
@@ -16,8 +16,8 @@ Below are resources for this release:
 
  * Download a release tarball and verify by these [procedures] using these [KEYS]
  
-   | [fluo-yarn-1.0.0-bin.tar.gz][bin-release]            | [ASC][bin-asc] [SHA-512][bin-sha] |
-   | [fluo-yarn-1.0.0-source-release.tar.gz][src-release] | [ASC][src-asc] [SHA-512][src-sha] |
+   | [fluo-yarn-1.0.0-bin.tar.gz][bin-release]            | [ASC][bin-asc] [SHA][bin-sha] |
+   | [fluo-yarn-1.0.0-source-release.tar.gz][src-release] | [ASC][src-asc] [SHA][src-sha] |
  * View [documentation][docs] for to learn how to run Fluo application in YARN.
 
 ### Testing


### PR DESCRIPTION
* Update hashes to drop use of MD5
* Use .sha512 naming convention
* Make hash links consistent in markdown
* Add repository information for GitHub jekyll plugin

See https://www.apache.org/dev/release-distribution.html#sigs-and-sums