### PR TITLE
Drop IRC as a contact method

### DIFF
--- a/pages/contactus.md
+++ b/pages/contactus.md
@@ -45,10 +45,6 @@ current issues.
  * [Fluo Mucho issues][mi]
  * [Fluo Examples issues][ei]
 
-### IRC
-
-Drop by and chat about Apache Fluo at [#fluo][fnf] on [freenode][fn].
-
 ### Contributions 
 
 Contributions are welcome to all Apache Fluo projects! If you would like help getting started contributing, please contact us on the dev list.  We will work with you to help find something that interest you.  All projects follow a [review-then-commit][rtc] process. If you are interested in contributing, read our [How To Contribute][htc] page.
@@ -65,8 +61,6 @@ Contributions are welcome to all Apache Fluo projects! If you would like help ge
 [ui]: https://github.com/apache/fluo-uno/issues
 [mi]: https://github.com/apache/fluo-muchos/issues
 [ei]: https://github.com/apache/fluo-examples/issues
-[fnf]: irc://chat.freenode.net/fluo
-[fn]: https://freenode.net/
 [htc]: /how-to-contribute/
 [rtc]: https://www.apache.org/foundation/glossary.html#ReviewThenCommit
 [dev-arch]: https://lists.apache.org/list.html?dev@fluo.apache.org

--- a/tour/index.md
+++ b/tour/index.md
@@ -25,7 +25,7 @@ updated using them. Later in the tour, you can implement this use case.
 We recommend following the tour in order. However, all pages are listed below for review.  When on a
 tour page, the left and right keys on the keyboard can be used to navigate.  If you have any
 questions or suggestions while going through the tour, please contact us.  There are multiple
-options for getting in touch : [mailing list, IRC][contact], and [GitHub Issues][issues].  Any
+options for getting in touch : [mailing list][contact] and [GitHub Issues][issues].  Any
 thoughts, solutions, etc  related to this tour can also be tweeted using the hashtag
 [#apachefluotour][aft].
 


### PR DESCRIPTION
Remove references to IRC/FreeNode channel '#fluo' in our contact
information. It hasn't been used in months and the channel was
deregistered.