### PR TITLE
Updated download links to use new ASF URL

### DIFF
--- a/_posts/release/2018-02-26-fluo-1.2.0.md
+++ b/_posts/release/2018-02-26-fluo-1.2.0.md
@@ -170,13 +170,13 @@ The Fluo stress test was run twice as documented [here](https://twitter.com/Apac
 [Percolator]: https://research.google.com/pubs/pub36726.html
 [Apache Accumulo]: https://accumulo.apache.org/
 [procedures]: https://www.apache.org/info/verification
-[KEYS]: https://www.apache.org/dist/fluo/KEYS
+[KEYS]: https://downloads.apache.org/fluo/KEYS
 [bin-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz
-[bin-asc]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.asc
-[bin-sha]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.sha512
+[bin-asc]: https://downloads.apache.org/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.asc
+[bin-sha]: https://downloads.apache.org/fluo/fluo/1.2.0/fluo-1.2.0-bin.tar.gz.sha512
 [src-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz
-[src-asc]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.asc
-[src-sha]: https://www.apache.org/dist/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.sha512
+[src-asc]: https://downloads.apache.org/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.asc
+[src-sha]: https://downloads.apache.org/fluo/fluo/1.2.0/fluo-1.2.0-source-release.tar.gz.sha512
 [javadocs]: {{ site.fluo_api_base }}/1.2.0/
 [docs]: /docs/fluo/1.2/
 [semver]: http://semver.org/

--- a/_posts/release/2018-03-06-fluo-recipes-1.2.0.md
+++ b/_posts/release/2018-03-06-fluo-recipes-1.2.0.md
@@ -38,10 +38,10 @@ Fluo Recipes was updated (in [#146]) to build using Fluo 1.2.0 and Accumulo 1.7.
 [#144]: https://github.com/apache/fluo-recipes/pull/144
 [#146]: https://github.com/apache/fluo-recipes/pull/146
 [procedures]: https://www.apache.org/info/verification
-[KEYS]: https://www.apache.org/dist/fluo/KEYS
+[KEYS]: https://downloads.apache.org/fluo/KEYS
 [src-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz
-[src-asc]: https://www.apache.org/dist/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.asc
-[src-sha]: https://www.apache.org/dist/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.sha512
+[src-asc]: https://downloads.apache.org/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.asc
+[src-sha]: https://downloads.apache.org/fluo/fluo-recipes/1.2.0/fluo-recipes-1.2.0-source-release.tar.gz.sha512
 [docs]: /docs/fluo-recipes/1.2/
 [central]: http://search.maven.org/#search|ga|1|fluo-recipes
 [changes]: https://github.com/apache/fluo-recipes/milestone/2?closed=1

--- a/_posts/release/2018-03-06-fluo-yarn-1.0.0.md
+++ b/_posts/release/2018-03-06-fluo-yarn-1.0.0.md
@@ -25,13 +25,13 @@ Below are resources for this release:
 While testing Fluo 1.2.0, two stress test runs used an unreleased version of Fluo YARN.
  
 [procedures]: https://www.apache.org/info/verification
-[KEYS]: https://www.apache.org/dist/fluo/KEYS
+[KEYS]: https://downloads.apache.org/fluo/KEYS
 [bin-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-bin.tar.gz
-[bin-asc]: https://www.apache.org/dist/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-bin.tar.gz.asc
-[bin-sha]: https://www.apache.org/dist/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-bin.tar.gz.sha512
+[bin-asc]: https://downloads.apache.org/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-bin.tar.gz.asc
+[bin-sha]: https://downloads.apache.org/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-bin.tar.gz.sha512
 [src-release]: https://www.apache.org/dyn/closer.lua/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-source-release.tar.gz
-[src-asc]: https://www.apache.org/dist/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-source-release.tar.gz.asc
-[src-sha]: https://www.apache.org/dist/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-source-release.tar.gz.sha512
+[src-asc]: https://downloads.apache.org/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-source-release.tar.gz.asc
+[src-sha]: https://downloads.apache.org/fluo/fluo-yarn/1.0.0/fluo-yarn-1.0.0-source-release.tar.gz.sha512
 [docs]: /docs/fluo/1.2/administration/run-fluo-in-yarn
 [fluo-yarn]: https://github.com/apache/fluo-yarn
 [YARN]: https://hadoop.apache.org/docs/r2.8.0/hadoop-yarn/hadoop-yarn-site/YARN.html


### PR DESCRIPTION
Ran the following command in _posts/release

sed -i '' 's#https://www.apache.org/dist/fluo#https://downloads.apache.org/fluo#' *.md