### PR TITLE
Update ASF current-event logo display mechanism

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://www.apachecon.com/event-images/snippet.js"></script>
     {% include scripts.html %}
   </head>
   <body style="padding-top: 100px">

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ html_title_override: true
     </div>
     <div class="row">
       <div class="col-sm-12">
-        <a id="asf-current-event-logo" href="https://www.apache.org/events/current-event.html"><img alt="ASF Current Events" class="img-responsive center-block" src="https://www.apache.org/events/current-event-234x60.png"/></a>
+        <a class="acevent" data-class="img-responsive center-block" data-format="wide" data-mode="light" data-width="240"></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* Update the current-event logo display mechanism as described at
  https://www.apachecon.com/event-images/