### PR TITLE
Add development Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# This Dockerfile builds an ruby environment for jekyll that empowers
+# making updates to the website without requiring the dev
+# to maintain a local ruby development environment.
+
+FROM ruby:3.2.2-slim-bullseye AS base
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /mnt/workdir
+
+# Copy over the Gemfiles so that all build dependencies are installed
+# during the docker build. At runtime, these will be available to Jekyll
+# from the mounted directory. But that's not available during the
+# docker build, so we need to copy them in to pre-install the Gems
+
+COPY Gemfile Gemfile.lock ./
+
+# Gems will be installed under GEM_HOME which is set by the ruby image.
+# See https://hub.docker.com/_/ruby for details.
+
+RUN gem update --system \
+  && bundle install \
+  && gem cleanup
+
+ENV HOST=0.0.0.0 \
+    PORT=4000
+
+EXPOSE $PORT
+
+# Configure the default command to build from the mounted repository.
+CMD bundle exec jekyll serve -H $HOST -P $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ruby:3.2.2-slim-bullseye AS base
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt update && apt install -y --no-install-recommends \
     build-essential \
     git \
     curl \
@@ -26,8 +26,8 @@ RUN gem update --system \
   && bundle install \
   && gem cleanup
 
-ENV HOST=0.0.0.0 \
-    PORT=4000
+ENV HOST=0.0.0.0
+ENV PORT=4000
 
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -79,3 +79,43 @@ branch, where they will be served on [our production site][production].
 [li]: http://img.shields.io/badge/license-ASL-blue.svg
 [ll]: https://github.com/apache/fluo-website/blob/main/LICENSE
 
+## Testing using Docker environment 
+
+A containerized development environment can be built using the local
+Dockerfile. You can build it with the following command:
+
+```bash
+docker build -t fluo-site-dev .
+```
+
+This action will produce a `fluo-site-dev` image, with all the website's build
+prerequisites preinstalled. When a container is run from this image, it
+will perform a `jekyll serve` command with the polling option enabled,
+so that changes you make locally will be immediately reflected after
+reloading the page in your browser.
+
+When you run a container using the `fluo-site-dev` image, your current working
+directory will be mounted, so that any changes made by the build inside
+the container will be reflected in your local workspace. This is done with
+the `-v` flag. To run the container, execute the following command:
+
+```bash
+docker run -it -v "$PWD":/mnt/workdir -p 4000:4000 fluo-site-dev
+```
+
+While this container is running, you will be able to review the rendered website
+in your local browser at the address printed in the shell ([http://0.0.0.0:4000/](http://0.0.0.0:4000/)).
+
+Running with `-it` will provide shell access. This is useful for adding new 
+gems, or modifying the Gemfile.lock for updating existing dependencies.
+
+When using shell access, the local directory must be mounted to ensure
+the Gemfile and Gemfile.lock updates are reflected in your local
+environment so you can create a commit and submit a PR.
+
+```bash
+docker run -it -v "$PWD":/mnt/workdir -p 4000:4000 fluo-site-dev /bin/bash
+```
+
+You may need to manually delete the `_site` or `.jekyll-cache` directories if
+they already exist and are causing issues with the build.

--- a/README.md
+++ b/README.md
@@ -72,13 +72,6 @@ Changes pushed to our `main` branch will automatically trigger [Jekyll] to
 build our site from that branch and push the result to our `asf-site`
 branch, where they will be served on [our production site][production].
 
-[Jekyll]: https://jekyllrb.com/
-[production]: https://fluo.apache.org
-[ti]: https://github.com/apache/fluo-website/workflows/CI/badge.svg
-[tl]: https://github.com/apache/fluo-website/actions
-[li]: http://img.shields.io/badge/license-ASL-blue.svg
-[ll]: https://github.com/apache/fluo-website/blob/main/LICENSE
-
 ## Testing using Docker environment 
 
 A containerized development environment can be built using the local
@@ -106,16 +99,18 @@ docker run -it -v "$PWD":/mnt/workdir -p 4000:4000 fluo-site-dev
 While this container is running, you will be able to review the rendered website
 in your local browser at the address printed in the shell ([http://0.0.0.0:4000/](http://0.0.0.0:4000/)).
 
-Running with `-it` will provide shell access. This is useful for adding new 
+Appending `/bin/bash` to the end of the docker command above will provide shell access. This is useful for adding new 
 gems, or modifying the Gemfile.lock for updating existing dependencies.
-
 When using shell access, the local directory must be mounted to ensure
 the Gemfile and Gemfile.lock updates are reflected in your local
 environment so you can create a commit and submit a PR.
 
-```bash
-docker run -it -v "$PWD":/mnt/workdir -p 4000:4000 fluo-site-dev /bin/bash
-```
-
 You may need to manually delete the `_site` or `.jekyll-cache` directories if
 they already exist and are causing issues with the build.
+
+[Jekyll]: https://jekyllrb.com/
+[production]: https://fluo.apache.org
+[ti]: https://github.com/apache/fluo-website/workflows/CI/badge.svg
+[tl]: https://github.com/apache/fluo-website/actions
+[li]: http://img.shields.io/badge/license-ASL-blue.svg
+[ll]: https://github.com/apache/fluo-website/blob/main/LICENSE


### PR DESCRIPTION
This PR adds a development dockerfile and corresponding instructions to the readme.

This dockerfile and readme section were mostly copied from the accumulo-website dockerfile and readme.